### PR TITLE
Support node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"
+  - "0.12"

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(options) {
 
   return {
     name: 'flow-remove-types',
-    transform(code, id) {
+    transform: function(code, id) {
       if (filter(id)) {
         return {
           code: flowRemoveTypes(code),


### PR DESCRIPTION
Hi, Lee! Nice to meet you. Rollup still supports 0.12 until december. I'd like to use your plugin in my prodution.
